### PR TITLE
feat: override user balance during gas estimation

### DIFF
--- a/packages/client/src/mud-login/getUserBalanceSlot.ts
+++ b/packages/client/src/mud-login/getUserBalanceSlot.ts
@@ -1,0 +1,16 @@
+import { resourceToHex } from "@latticexyz/common";
+import { Address, Hex, concatHex, hexToBigInt, keccak256, padHex, toBytes, toHex } from "viem";
+
+export function getUserBalanceSlot(user: Address) {
+  return _getStaticDataLocation(resourceToHex({ type: "table", namespace: "", name: "UserBalances" }), [
+    padHex(user, { dir: "left", size: 32 }),
+  ]);
+}
+
+// TODO: move to MUD
+
+const SLOT = hexToBigInt(keccak256(toBytes("mud.store")));
+
+function _getStaticDataLocation(tableId: Hex, keyTuple: Hex[]): Hex {
+  return toHex(SLOT ^ hexToBigInt(keccak256(concatHex([tableId, ...keyTuple]))));
+}

--- a/packages/client/src/mud-login/getUserBalanceSlot.ts
+++ b/packages/client/src/mud-login/getUserBalanceSlot.ts
@@ -2,15 +2,13 @@ import { resourceToHex } from "@latticexyz/common";
 import { Address, Hex, concatHex, hexToBigInt, keccak256, padHex, toBytes, toHex } from "viem";
 
 export function getUserBalanceSlot(user: Address) {
-  return _getStaticDataLocation(resourceToHex({ type: "table", namespace: "", name: "UserBalances" }), [
+  return getStaticDataLocation(resourceToHex({ type: "table", namespace: "", name: "UserBalances" }), [
     padHex(user, { dir: "left", size: 32 }),
   ]);
 }
 
-// TODO: move to MUD
-
+// TODO: move this util to MUD (equivalent of StoreCore._getStaticDataLocation)
 const SLOT = hexToBigInt(keccak256(toBytes("mud.store")));
-
-function _getStaticDataLocation(tableId: Hex, keyTuple: Hex[]): Hex {
+function getStaticDataLocation(tableId: Hex, keyTuple: Hex[]): Hex {
   return toHex(SLOT ^ hexToBigInt(keccak256(concatHex([tableId, ...keyTuple]))));
 }

--- a/packages/client/src/mud-login/useAppAccountClient.ts
+++ b/packages/client/src/mud-login/useAppAccountClient.ts
@@ -36,7 +36,6 @@ export function useAppAccountClient(): AppAccountClient | undefined {
       bundlerTransport: http("http://127.0.0.1:4337"),
       middleware: {
         sponsorUserOperation: async ({ userOperation }) => {
-          // TODO: why does the gas estimation fail but the call succeeds if the gas limits are hard coded?
           const gasEstimates = await pimlicoBundlerClient.estimateUserOperationGas(
             {
               userOperation: {
@@ -54,14 +53,6 @@ export function useAppAccountClient(): AppAccountClient | undefined {
               },
             },
           );
-
-          // const gasEstimates = {
-          //   preVerificationGas: 1_000_000n,
-          //   verificationGasLimit: 1_000_000n,
-          //   callGasLimit: 1_000_000n,
-          //   paymasterVerificationGasLimit: 1_000_000n,
-          //   paymasterPostOpGasLimit: 1_000_000n,
-          // };
 
           return {
             paymasterData: "0x",

--- a/packages/client/src/mud-login/useAppAccountClient.ts
+++ b/packages/client/src/mud-login/useAppAccountClient.ts
@@ -35,13 +35,23 @@ export function useAppAccountClient(): AppAccountClient | undefined {
       bundlerTransport: http("http://127.0.0.1:4337"),
       middleware: {
         sponsorUserOperation: async ({ userOperation }) => {
-          const gasEstimates = await pimlicoBundlerClient.estimateUserOperationGas({
-            userOperation: {
-              ...userOperation,
-              paymaster: gasTankAddress,
-              paymasterData: "0x",
-            },
-          });
+          // TODO: why does the gas estimation fail but the call succeeds if the gas limits are hard coded?
+
+          // const gasEstimates = await pimlicoBundlerClient.estimateUserOperationGas({
+          //   userOperation: {
+          //     ...userOperation,
+          //     paymaster: gasTankAddress,
+          //     paymasterData: "0x",
+          //   },
+          // });
+
+          const gasEstimates = {
+            preVerificationGas: 1_000_000n,
+            verificationGasLimit: 1_000_000n,
+            callGasLimit: 1_000_000n,
+            paymasterVerificationGasLimit: 1_000_000n,
+            paymasterPostOpGasLimit: 1_000_000n,
+          };
 
           return {
             paymasterData: "0x",

--- a/packages/client/src/mud-login/useAppAccountClient.ts
+++ b/packages/client/src/mud-login/useAppAccountClient.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useAccount, usePublicClient } from "wagmi";
-import { http, maxUint256, toHex, weiUnits } from "viem";
+import { http, maxUint256, toHex } from "viem";
 import { callFrom } from "@latticexyz/world/internal";
 import { createSmartAccountClient } from "permissionless";
 import { createPimlicoBundlerClient } from "permissionless/clients/pimlico";

--- a/packages/client/src/mud-login/useAppAccountClient.ts
+++ b/packages/client/src/mud-login/useAppAccountClient.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useAccount, usePublicClient } from "wagmi";
-import { http, maxUint256, toHex } from "viem";
+import { http, maxUint256, toHex, weiUnits } from "viem";
 import { callFrom } from "@latticexyz/world/internal";
 import { createSmartAccountClient } from "permissionless";
 import { createPimlicoBundlerClient } from "permissionless/clients/pimlico";
@@ -50,7 +50,7 @@ export function useAppAccountClient(): AppAccountClient | undefined {
               // the cost would exceed the user's balance.
               // We override the user's balance in the paymaster contract to make the gas estimation succeed.
               [gasTankAddress]: {
-                state: { [getUserBalanceSlot(userAddress)]: toHex(maxUint256) },
+                stateDiff: { [getUserBalanceSlot(userAddress)]: toHex(maxUint256) },
               },
             },
           );


### PR DESCRIPTION
With hardcoded gas limits, the call to register a spender via a signature succeeds.
Without hardcoded gas limits, the call fails with the following error:


Error: EstimateUserOperationGasError: The validatePaymasterUserOp function of the paymaster 0x either reverted or ran out of gas. Possible solutions: • Verify that the verificationGasLimit is high enough to cover the validatePaymasterUserOp function's gas costs. • If you are using your own paymaster contract, verify that the validatePaymasterUserOp function is implemented with the correct logic, and that the user operation is supposed to be valid. • If you are using a paymaster service, and the user operation is well formed with a high enough verificationGasLimit, reach out to them. • If you are not looking to use a paymaster to cover the gas fees, verify that the paymasterAndData field is not set. Docs: https://docs.pimlico.io/bundler/reference/entrypoint-errors/aa33 Estimate Gas Arguments: sender: 0x2A9A54f45b7Eba1a4249eD196fEdc6aBC8A660ab nonce: 0 callData: 0xb61d27f6000000000000000000000000c7b0b46dc0a1131adbdb8762a2773f2769abb5270000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001641fae63080000000000000000000000001c221b27e14656dec55b8a84494a1b3a2821bf4b737900000000000000000000000000005061796d617374657253797374656d00000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000000024960654620000000000000000000000002a9a54f45b7eba1a4249ed196fedc6abc8a660ab0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000411a467dfc95c8a111ad0d25d07a291a3c4b67e0cb012eaed19a6efd3f4f30536c620f4d5f358030f692cb7c5bf597b1ae6675cc80ce1d66765215840d97e46d521c0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 callGasLimit: 0 verificationGasLimit: 0 preVerificationGas: 0 maxFeePerGas: 1150000000 maxPriorityFeePerGas: 1150000000 signature: 0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c entryPoint: 0x0000000071727De22E5E9d8BAf0edAc6f37da032 Details: UserOperation reverted during simulation with reason: AA33 reverted Version: viem@2.7.12


